### PR TITLE
Fix version splitting, update MinIO commands, and update branch list

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - slimevr-network
       - caddy-network
   slimevr-api-s3-init:
-    image: minio/mc
+    image: minio/mc:latest
     depends_on:
       - slimevr-api-s3
     networks:
@@ -72,8 +72,9 @@ services:
     entrypoint: >
       /bin/sh -c "
       /usr/bin/mc alias set slimevr http://slimevr-api-s3:9099 `cat /run/secrets/access_key` `cat /run/secrets/secret_key`;
-      /usr/bin/mc mb slimevr/slimevr-firmware-builds;
-      /usr/bin/mc policy set public slimevr/slimevr-firmware-builds;
+      /usr/bin/mc admin update slimevr;
+      /usr/bin/mc mb --ignore-existing slimevr/slimevr-firmware-builds;
+      /usr/bin/mc anonymous set public slimevr/slimevr-firmware-builds;
       exit 0;
       "
 

--- a/backend/src/firmware/firmware.service.ts
+++ b/backend/src/firmware/firmware.service.ts
@@ -445,11 +445,8 @@ export class FirmwareService implements OnApplicationBootstrap {
 
   public async buildFirmware(dto: BuildFirmwareDTO): Promise<BuildResponse> {
     try {
-      const splitVersion = dto.version.split('/', 2);
-
-      const owner = splitVersion.length > 1 ? splitVersion[0] : 'SlimeVR';
+      const [_, owner, version] = dto.version.match(/(.*?)\/(.*)/) || [undefined, 'SlimeVR', dto.version];
       let repo = 'SlimeVR-Tracker-ESP';
-      const version = splitVersion.length > 1 ? splitVersion[1] : splitVersion[0];
 
       // TODO: Make the site say what repo to use, please
       // If there's a matching owner

--- a/backend/src/firmware/firmwares.json
+++ b/backend/src/firmware/firmwares.json
@@ -1,6 +1,6 @@
 {
   "SlimeVR": {
-    "SlimeVR-Tracker-ESP": ["main"]
+    "SlimeVR-Tracker-ESP": ["main", "beta/bmi-improvements"]
   },
   "deiteris": {
     "SlimeVR-Tracker-ESP": ["qmc-mag-new", "hmc-mag"]

--- a/backend/src/firmware/firmwares.json
+++ b/backend/src/firmware/firmwares.json
@@ -14,7 +14,7 @@
   "0forks": {
     "SlimeVR-Tracker-ESP-BMI160": ["v3dev", "v3dev-bmm"]
   },
-  "ButterscotchV": {
-    "SlimeVR-Tracker-ESP": ["arduino-latest"]
+  "ThreadOfFate": {
+    "SlimeVR-Tracker-ESP": ["IMUAddressUpdate"]
   }
 }

--- a/frontend/src/components/firmware-tool/FirmwareTool.tsx
+++ b/frontend/src/components/firmware-tool/FirmwareTool.tsx
@@ -31,6 +31,7 @@ export function FirmwareTool() {
             <Alert variant="outlined" severity="info" sx={{ my: 2 }}>
                 SlimeVR/vX.X.X - SlimeVR stable release(s)
                 <p><Link href="https://github.com/SlimeVR/SlimeVR-Tracker-ESP/tree/main">SlimeVR/main</Link> - SlimeVR development branch</p>
+                <p><Link href="https://github.com/SlimeVR/SlimeVR-Tracker-ESP/tree/beta/bmi-improvements">SlimeVR/beta/bmi-improvements</Link> - Improves support for the BMI160</p>
                 <p><Link href="https://github.com/deiteris/SlimeVR-Tracker-ESP/tree/qmc-mag-new">deiteris/qmc-mag-new</Link> - For use with the MPU6050/MPU6500 + QMC5883L external magnetometer configuration</p>
                 <p><Link href="https://github.com/deiteris/SlimeVR-Tracker-ESP/tree/hmc-mag">deiteris/hmc-mag</Link> - For use with the MPU6050/MPU6500 + HMC5883L external magnetometer configuration</p>
                 <p><Link href="https://github.com/tianrui233/SlimeVR-Tracker-ESP-For-Kitkat/tree/qmc-axis-aligned-en">tianrui233/qmc-axis-aligned-en</Link> - Forked from "deiteris/qmc-mag-new", but XYZ axis aligned</p>

--- a/frontend/src/components/firmware-tool/FirmwareTool.tsx
+++ b/frontend/src/components/firmware-tool/FirmwareTool.tsx
@@ -38,7 +38,7 @@ export function FirmwareTool() {
                 <p><Link href="https://github.com/Lupinixx/SlimeVR-Tracker-ESP/tree/mpu6050-fifo">Lupinixx/mpu6050-fifo</Link> - Attempts to use a FIFO + VQF filter for the imu</p>
                 <p><Link href="https://github.com/0forks/SlimeVR-Tracker-ESP-BMI160/tree/v3dev">0forks/v3dev</Link> - Improves support for the BMI160</p>
                 <p><Link href="https://github.com/0forks/SlimeVR-Tracker-ESP-BMI160/tree/v3dev-bmm">0forks/v3dev-bmm</Link> - Improves support for the BMI160 and adds support for the BMM150</p>
-                <p><Link href="https://github.com/ButterscotchV/SlimeVR-Tracker-ESP/tree/arduino-latest">ButterscotchV/arduino-latest</Link> - Uses the latest Arduino framework</p>
+                <p><Link href="https://github.com/ThreadOfFate/SlimeVR-Tracker-ESP/tree/IMUAddressUpdate">ThreadOfFate/IMUAddressUpdate</Link> - Fixes IMU sensorIDs</p>
             </Alert>
             <Alert variant="filled" severity="warning" sx={{ my: 2 }}>
                 IMPORTANT NOTICE: The IMU Rotation option has changed, please be aware that the values used before may need to be modified to function properly (90 deg and 270 deg have been swapped, so it should now follow SlimeVR's documentation).


### PR DESCRIPTION
**IMPORTANT NOTE**: If merged, you will likely need to pull the latest MinIO images for the commands to work properly. Please pay close attention to the output and ensure the builds are still publicly accessible. You may wish to add the `-x` option to `/bin/sh` in order to see what commands are being run for the output.

- Fixes version splitting ignoring anything in the branch name past any contained forward slashes (`/`)
- Updates MinIO commands to work with the latest version and update the database server
- Updates the branches to list, adding `SlimeVR/beta/bmi-improvements` and `ThreadOfFate/IMUAddressUpdate`, and removing `ButterscotchV/arduino-latest`