### PR TITLE
Add cache control headers and make repos fetch asynchronously

### DIFF
--- a/backend/src/firmware/firmware.controller.ts
+++ b/backend/src/firmware/firmware.controller.ts
@@ -38,7 +38,7 @@ export class FirmwareController {
   ) {}
 
   @Get('/')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiResponse({ type: [Firmware] })
   getFirmwares() {
     return this.firmwareService.getFirmwares();
@@ -62,7 +62,7 @@ export class FirmwareController {
   }
 
   @Get('/boards')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiOkResponse({ type: [BoardTypeBoard] })
   getBoardsTypes(): BoardTypeBoard[] {
     return Object.keys(BoardType).map((board) => ({
@@ -72,28 +72,28 @@ export class FirmwareController {
   }
 
   @Get('/versions')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiOkResponse({ type: [ReleaseDTO] })
   async getVersions(): Promise<ReleaseDTO[]> {
     return this.githubService.getAllReleases();
   }
 
   @Get('/imus')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiOkResponse({ type: [IMUDTO] })
   getIMUSTypes(): IMUDTO[] {
     return IMUS;
   }
 
   @Get('/batteries')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiOkResponse({ type: [String] })
   getBatteriesTypes(): string[] {
     return Object.keys(BatteryType);
   }
 
   @Get('/default-config/:board')
-  @Header('Cache-Control', 'public, max-age=7200, immutable')
+  @Header('Cache-Control', 'public, max-age=7200')
   @ApiOkResponse({ type: BuildFirmwareDTO })
   getDefaultConfig(@Param('board') board: BoardType): BuildFirmwareDTO {
     const dto = new BuildFirmwareDTO();

--- a/backend/src/firmware/firmware.controller.ts
+++ b/backend/src/firmware/firmware.controller.ts
@@ -38,6 +38,7 @@ export class FirmwareController {
   ) {}
 
   @Get('/')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiResponse({ type: [Firmware] })
   getFirmwares() {
     return this.firmwareService.getFirmwares();
@@ -61,6 +62,7 @@ export class FirmwareController {
   }
 
   @Get('/boards')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiOkResponse({ type: [BoardTypeBoard] })
   getBoardsTypes(): BoardTypeBoard[] {
     return Object.keys(BoardType).map((board) => ({
@@ -70,24 +72,28 @@ export class FirmwareController {
   }
 
   @Get('/versions')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiOkResponse({ type: [ReleaseDTO] })
   async getVersions(): Promise<ReleaseDTO[]> {
     return this.githubService.getAllReleases();
   }
 
   @Get('/imus')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiOkResponse({ type: [IMUDTO] })
   getIMUSTypes(): IMUDTO[] {
     return IMUS;
   }
 
   @Get('/batteries')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiOkResponse({ type: [String] })
   getBatteriesTypes(): string[] {
     return Object.keys(BatteryType);
   }
 
   @Get('/default-config/:board')
+  @Header('Cache-Control', 'public, max-age=7200, immutable')
   @ApiOkResponse({ type: BuildFirmwareDTO })
   getDefaultConfig(@Param('board') board: BoardType): BuildFirmwareDTO {
     const dto = new BuildFirmwareDTO();

--- a/backend/src/firmware/firmware.controller.ts
+++ b/backend/src/firmware/firmware.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Header,
   HttpException,
   HttpStatus,
   Param,
@@ -43,6 +44,7 @@ export class FirmwareController {
   }
 
   @Post('/build')
+  @Header('Cache-Control', 'no-cache')
   @ApiOperation({
     description: 'Build a specific configuration of the firmware',
   })
@@ -53,6 +55,7 @@ export class FirmwareController {
   }
 
   @Sse('/build-status/:id')
+  @Header('Cache-Control', 'no-cache')
   buildStatus(@Param('id') id: string) {
     return this.firmwareService.getBuildStatusSubject(id);
   }
@@ -100,6 +103,7 @@ export class FirmwareController {
   }
 
   @Get('/:id')
+  @Header('Cache-Control', 'no-cache')
   @ApiResponse({ type: Firmware })
   @ApiNotFoundResponse()
   async getFirmware(@Param('id') id: string) {

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -89,14 +89,14 @@ export class GithubService {
   }
 
   async getAllReleases(): Promise<ReleaseDTO[]> {
-    const releases: ReleaseDTO[] = [];
+    const releases: Promise<ReleaseDTO | ReleaseDTO[]>[] = [];
 
     
     for (let [owner, repos] of Object.entries(AVAILABLE_FIRMWARE_REPOS)) {
       for (let [repo, branches] of Object.entries(repos)) {
         // Get all repo releases
         try {
-          releases.push(...await this.getReleases(owner, repo));
+          releases.push(this.getReleases(owner, repo));
         } catch (e) {
           console.error(`Unable to fetch releases for "${owner}/${repo}": `, e);
         }
@@ -104,7 +104,7 @@ export class GithubService {
         // Get each branch as a release version
         for (let branch of branches) {
           try {
-            releases.push(await this.getBranchRelease(owner, repo, branch));
+            releases.push(this.getBranchRelease(owner, repo, branch));
           } catch (e) {
             console.error(`Unable to fetch branch release for "${owner}/${repo}/${branch}": `, e);
           }
@@ -112,7 +112,7 @@ export class GithubService {
       }
     }
 
-    return releases;
+    return Promise.all(releases).then(value => value.flat());
   }
 
   async getRelease(

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -95,11 +95,11 @@ export class GithubService {
     for (let [owner, repos] of Object.entries(AVAILABLE_FIRMWARE_REPOS)) {
       for (let [repo, branches] of Object.entries(repos)) {
         // Get all repo releases
-        releases.push(this.getReleases(owner, repo).catch((e) => {throw `Unable to fetch releases for "${owner}/${repo}": ${e}`;}));
+        releases.push(this.getReleases(owner, repo).catch((e) => { throw new Error(`Unable to fetch releases for "${owner}/${repo}"`, { cause: e }); }));
 
         // Get each branch as a release version
         for (let branch of branches) {
-          releases.push(this.getBranchRelease(owner, repo, branch).catch((e) => {throw `Unable to fetch branch release for "${owner}/${repo}/${branch}": ${e}`;}));
+          releases.push(this.getBranchRelease(owner, repo, branch).catch((e) => { throw new Error(`Unable to fetch branch release for "${owner}/${repo}/${branch}"`, { cause: e }); }));
         }
       }
     }
@@ -109,7 +109,7 @@ export class GithubService {
       if (it.status === 'fulfilled') {
         return it.value;
       }
-      console.warn(it.reason);
+      console.warn(`${it.reason.message}: `, it.reason.cause);
       return []; // Needed for filtering invalid promises
     });
   }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "target": "es2017",
+    "target": "es2019",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,7 +7,7 @@
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "target": "es2019",
+    "target": "es2022",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
- Adds cache control headers to API endpoints
  - `no-cache` for endpoints that require fresh data
    - Note: This header may be ignored for EventStreams. EventStreams are only used by `buildStatus`, so you may need to add an exception for that endpoint in the case that you enable some sort of caching.
  - `public, max-age=7200` for endpoints that don't need frequent updates
    - Note: The `max-age` is set to 2 hours as that's a fairly standard minimum time for caching services (ex. CloudFlare), if a refresh is needed sooner than this, the cache can be purged manually
- Makes repo fetching asynchronous, this decreases the repo list loading time significantly
- Updates the target TypeScript version from `es2017` to `es2022`, as it's required for some code present in this PR