### PR TITLE
Update firmware list

### DIFF
--- a/backend/src/firmware/firmwares.json
+++ b/backend/src/firmware/firmwares.json
@@ -1,6 +1,6 @@
 {
   "SlimeVR": {
-    "SlimeVR-Tracker-ESP": ["main", "beta/bmi-improvements"]
+    "SlimeVR-Tracker-ESP": ["main"]
   },
   "deiteris": {
     "SlimeVR-Tracker-ESP": ["qmc-mag-new", "hmc-mag"]
@@ -14,13 +14,10 @@
   "0forks": {
     "SlimeVR-Tracker-ESP-BMI160": ["v3dev", "v3dev-bmm"]
   },
-  "ThreadOfFate": {
-    "SlimeVR-Tracker-ESP": ["IMUAddressUpdate"]
-  },
   "unlogisch04": {
     "SlimeVR-Tracker-ESP": ["feat_commitid"]
   },
   "ButterscotchV": {
-    "SlimeVR-Tracker-ESP": ["bmi-plus-address-fix", "mag-enabled-stable", "mag-enabled-main"]
+    "SlimeVR-Tracker-ESP": ["mag-enabled-stable", "mag-enabled-main"]
   }
 }

--- a/frontend/src/components/firmware-tool/FirmwareTool.tsx
+++ b/frontend/src/components/firmware-tool/FirmwareTool.tsx
@@ -31,16 +31,13 @@ export function FirmwareTool() {
             <Alert variant="outlined" severity="info" sx={{ my: 2 }}>
                 SlimeVR/vX.X.X - SlimeVR stable release(s)
                 <p><Link href="https://github.com/SlimeVR/SlimeVR-Tracker-ESP/tree/main">SlimeVR/main</Link> - SlimeVR development branch</p>
-                <p><Link href="https://github.com/SlimeVR/SlimeVR-Tracker-ESP/tree/beta/bmi-improvements">SlimeVR/beta/bmi-improvements</Link> - Improves support for the BMI160</p>
                 <p><Link href="https://github.com/deiteris/SlimeVR-Tracker-ESP/tree/qmc-mag-new">deiteris/qmc-mag-new</Link> - For use with the MPU6050/MPU6500 + QMC5883L external magnetometer configuration</p>
                 <p><Link href="https://github.com/deiteris/SlimeVR-Tracker-ESP/tree/hmc-mag">deiteris/hmc-mag</Link> - For use with the MPU6050/MPU6500 + HMC5883L external magnetometer configuration</p>
                 <p><Link href="https://github.com/TheBug233/SlimeVR-Tracker-ESP-For-Kitkat/tree/qmc-axis-aligned-en">TheBug233/qmc-axis-aligned-en</Link> - Forked from "deiteris/qmc-mag-new", but XYZ axis aligned</p>
                 <p><Link href="https://github.com/Lupinixx/SlimeVR-Tracker-ESP/tree/mpu6050-fifo">Lupinixx/mpu6050-fifo</Link> - Attempts to use a FIFO + VQF filter for the imu</p>
                 <p><Link href="https://github.com/0forks/SlimeVR-Tracker-ESP-BMI160/tree/v3dev">0forks/v3dev</Link> - Improves support for the BMI160</p>
                 <p><Link href="https://github.com/0forks/SlimeVR-Tracker-ESP-BMI160/tree/v3dev-bmm">0forks/v3dev-bmm</Link> - Improves support for the BMI160 and adds support for the BMM150</p>
-                <p><Link href="https://github.com/ThreadOfFate/SlimeVR-Tracker-ESP/tree/IMUAddressUpdate">ThreadOfFate/IMUAddressUpdate</Link> - Fixes IMU sensorIDs</p>
                 <p><Link href="https://github.com/unlogisch04/SlimeVR-Tracker-ESP/tree/feat_commitid">unlogisch04/feat_commitid</Link> - Testing adding git commit ID info</p>
-                <p><Link href="https://github.com/ButterscotchV/SlimeVR-Tracker-ESP/tree/bmi-plus-address-fix">ButterscotchV/bmi-plus-address-fix</Link> - Merged SlimeVR/beta/bmi-improvements and ThreadOfFate/IMUAddressUpdate</p>
                 <p><Link href="https://github.com/ButterscotchV/SlimeVR-Tracker-ESP/tree/mag-enabled-stable">ButterscotchV/mag-enabled-stable</Link> - The latest stable firmware release with 9 DoF ICM-20948 and BNO0xx (magnetometer enabled)</p>
                 <p><Link href="https://github.com/ButterscotchV/SlimeVR-Tracker-ESP/tree/mag-enabled-main">ButterscotchV/mag-enabled-main</Link> - Based off SlimeVR/main with 9 DoF ICM-20948 and BNO0xx (magnetometer enabled)</p>
             </Alert>


### PR DESCRIPTION
- Removes `SlimeVR/beta/bmi-improvements`, this has been merged into main and has been outdated
- Removes `ThreadOfFate/IMUAddressUpdate`, this has been merged into main
- Removes `ButterscotchV/bmi-plus-address-fix`, both branches have been merged into main, therefore this merged branch is outdated and no longer needed