### PR TITLE
Make visible wich branch failed to load

### DIFF
--- a/src/github/github.service.ts
+++ b/src/github/github.service.ts
@@ -153,7 +153,13 @@ export class GithubService {
         // And a matching branch
         if (repoBranches.includes(version)) {
           // Then return the branch release instead of looking for a version
-          return this.getBranchRelease(owner, repo, version);
+          return this.getBranchRelease(owner, repo, version)
+            .catch((e) => {
+              throw new Error(
+                `Unable to fetch branch release for "${owner}/${repo}/${version}"`,
+                { cause: e },
+              );
+            });
         }
       }
     }


### PR DESCRIPTION
When a repository is not available or accessible, the log output did not show what repository the error was from.
