### PR TITLE
Update 3rd party firmware list

### DIFF
--- a/src/firmware/firmwares.json
+++ b/src/firmware/firmwares.json
@@ -4,42 +4,21 @@
       "main"
     ]
   },
-  "deiteris": {
+  "kounocom": {
     "SlimeVR-Tracker-ESP": [
-      "qmc-mag-new",
-      "hmc-mag"
+      "sfusion-machine-optimized",
+      "dynamic-sfusion",
+      "sfusion-tuned-mbe"
     ]
   },
-  "TheBug233": {
-    "SlimeVR-Tracker-ESP-For-Kitkat": [
-      "qmc-axis-aligned-en"
-    ]
-  },
-  "Lupinixx": {
+  "gorbit99": {
     "SlimeVR-Tracker-ESP": [
-      "mpu6050-fifo"
+      "on-off-button"
     ]
   },
-  "0forks": {
-    "SlimeVR-Tracker-ESP-BMI160": [
-      "v3dev",
-      "v3dev-bmm"
-    ]
-  },
-  "unlogisch04": {
-    "SlimeVR-Tracker-ESP": [
-      "upd_espidf_pioarduino"
-    ]
-  },
-  "ButterscotchV": {
-    "SlimeVR-Tracker-ESP": [
-      "mag-enabled-stable",
-      "mag-enabled-main"
-    ]
-  },
-  "l0ud": {
-    "SlimeVR-Tracker-ESP-BMI270": [
-      "main"
+  "wigwagwent": {
+    "LSM6DSV16X": [
+      "BMI_senscal"
     ]
   }
 }


### PR DESCRIPTION
This PR removes old 3rd party firmware branches and adds some new ones:

Removals:

* `deiteris`, `TheBug223`, `Lupinixx`:
    - `qmc-mag-new`, `hmc-mag`, `qmc-axis-aligned-en` and `mpu6050-fifo` were removed due to being outdated and unused for a long time
* `0forks`:
    - `v3dev` was removed due to it's changes being merged into main a long time ago
    - `v3dev-bmm` was removed due to never really working properly
* `unlogisch`:
    - `upd_espidf_pioarduino` -- honestly not sure what this even does, but I haven't seen anyone use it, and it hasn't been updated for 5 months now
* `ButterscotchV`:
    - `mag-enabled-stable` and `mag-enabled-main` were removed due to redundancy -- mag can now be toggled in the server
* `l0ud`:
    - `main` was removed due to being an old, unmerged implementation of BMI270, where a better one currently exists in `SlimeVR/main`

Additions:

* `kounocom`:
    - `sfusion-machine-optimized` - based on latest `main`, disables IMU calibration and uses machine-optimized sensor fusion values
    - `dynamic-sfusion` - a rewrite of this is already in main, but it is not as well tested, and may not perform as well just yet
    - `sfusion-tuned-mbe` - shouldn't really be used but some people have calibration issues on `dynamic-sfusion` and `main`, and this branch still has explicit calibration
* `gorbit99`:
    - `on-off-button` - adds momentary pushbutton support to enter and wake from deep sleep
* `wigwagwent`:
    - `BMI_senscal` - adds interactive sensitivity calibration for BMI160 -- it's quite outdated, though some people still use it